### PR TITLE
update slug

### DIFF
--- a/backend/src/api/hackathon/content-types/hackathon/schema.json
+++ b/backend/src/api/hackathon/content-types/hackathon/schema.json
@@ -39,7 +39,7 @@
       "repeatable": true,
       "component": "qusetion.faq"
     },
-    "Slug": {
+    "slug": {
       "type": "string"
     },
     "Image": {

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -406,7 +406,7 @@ export interface ApiHackathonHackathon extends Struct.CollectionTypeSchema {
     RegistrationEndDate: Schema.Attribute.Date;
     RegistrationStartDate: Schema.Attribute.Date;
     Schedule: Schema.Attribute.JSON;
-    Slug: Schema.Attribute.String;
+    slug: Schema.Attribute.String;
     Theme: Schema.Attribute.String;
     Title: Schema.Attribute.String;
     updatedAt: Schema.Attribute.DateTime;


### PR DESCRIPTION
This pull request includes a small change to the `backend/src/api/hackathon/content-types/hackathon/schema.json` file. The change corrects the casing of the `slug` property to follow standard naming conventions.

* [`backend/src/api/hackathon/content-types/hackathon/schema.json`](diffhunk://#diff-6fe9191a9ee7435b9d8cf70e50b4a32b46b5222716c41362e686d04d8c80c86eL42-R42): Changed the property name from `Slug` to `slug` to follow standard naming conventions.