### PR TITLE
(middleware) update http link on https://hackwknd.sarawak.digital/

### DIFF
--- a/backend/config/middlewares.ts
+++ b/backend/config/middlewares.ts
@@ -21,7 +21,7 @@ module.exports = [
     name: 'strapi::cors',
     config: {
       enabled: true,
-      origin: ['http://localhost:3000', 'https://hackwknd.vercel.app'],
+      origin: ['http://localhost:3000', 'https://hackwknd.sarawak.digital/'],
       methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'],
       headers: ['Content-Type', 'Authorization', 'Origin', 'Accept'],
       keepHeaderOnError: true,


### PR DESCRIPTION
This pull request includes a change to the `backend/config/middlewares.ts` file to update the allowed origins for CORS configuration.

* [`backend/config/middlewares.ts`](diffhunk://#diff-b8d9dce0f006cc903bb20870520df4128a4b5cd6333454608c9e7581ecc46bfaL24-R24): Updated the CORS `origin` configuration to replace `https://hackwknd.vercel.app` with `https://hackwknd.sarawak.digital/`.